### PR TITLE
Resolve invisible data point bug

### DIFF
--- a/src/components/charts/scatterplot.svelte
+++ b/src/components/charts/scatterplot.svelte
@@ -46,7 +46,7 @@
     let r_scale
     $: r_scale = rScaleType()
         .domain(extent(data, r_accessor))
-        .range([0, radius])
+        .range([5, radius])
 
     let x_scale, xGet
     let y_scale, yGet


### PR DESCRIPTION
Increases minimum size of circles from 0r to 5r so that the lowest data point is still rendered. This fixes an issue where the lowest data point in the collection has a radius of 0. This is especially noticeable for new users when they might have only a few data points.

Before:
![image](https://github.com/user-attachments/assets/f5e5ca94-a71f-4805-9633-01b4aa750777)

After:
![image](https://github.com/user-attachments/assets/0e18c114-7736-4e2a-853e-1d51730d5b36)
