### PR TITLE
Added development dependency `web-ext` to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
             typescript
             prettier
             pkgs.vtsls
+            web-ext
           ];
         };
       }


### PR DESCRIPTION
Added this for any fellow nix-users so they don't have to manually install `web-ext`